### PR TITLE
AB#654 Add integer filter for POST products_id on request_port.php

### DIFF
--- a/filter/standard.json
+++ b/filter/standard.json
@@ -2879,5 +2879,22 @@
     ],
     "function": "only_hex_code",
     "severity": "error"
+  },
+
+  {
+    "key": "Integer-Filter 50",
+    "script_name": "request_port.php",
+    "variables": [
+      {
+        "type": "POST",
+        "property": "products_id"
+      },
+      {
+        "type": "POST",
+        "property": "products_qty"
+      }
+    ],
+    "function": "convert_to_integer",
+    "severity": "error"
   }
 ]

--- a/filter/standard.json
+++ b/filter/standard.json
@@ -2888,13 +2888,22 @@
       {
         "type": "POST",
         "property": "products_id"
-      },
+      }
+    ],
+    "function": "convert_to_integer",
+    "severity": "error"
+  },
+
+  {
+    "key": "Float-Filter 1",
+    "script_name": "request_port.php",
+    "variables": [
       {
         "type": "POST",
         "property": "products_qty"
       }
     ],
-    "function": "convert_to_integer",
+    "function": "convert_to_float",
     "severity": "error"
   }
 ]

--- a/functions/main.inc.php
+++ b/functions/main.inc.php
@@ -13,6 +13,11 @@ function gprotector_convert_to_integer($p_variable)
     return (string)(int)$p_variable;
 }
 
+function gprotector_convert_to_float($p_variable)
+{
+    return (string)(float)$p_variable;
+}
+
 function gprotector_only_alphabetic($p_variable)
 {
     return preg_replace('/[^a-zA-Z]/', '', (string)$p_variable);


### PR DESCRIPTION
## Description

Adds a GProtector integer filter for `POST products_id` and `POST products_qty` on `request_port.php`.

Currently, GProtector only filters `GET module`, `GET action`, and `GET key` on `request_port.php` — but the `POST products_id` parameter was unfiltered, allowing SQL injection via the Attributes price calculation endpoint (`request_port.php?module=Attributes&action=calculate_price`).

**This vulnerability was actively exploited in the wild.**

Adding this filter protects all shops (including older versions) without requiring a shop update, since GProtector auto-updates its filter rules from `protect.gambio-server.net`.

## Changes

- `filter/standard.json`: Added `Integer-Filter 50` — converts `POST products_id` and `POST products_qty` to integer for `request_port.php`

## Testing

- [ ] POST to `request_port.php?module=Attributes&action=calculate_price` with `products_id=55" AND 1=1` — GProtector blocks/sanitizes the request
- [ ] Normal attribute price calculation still works with integer `products_id`
- [ ] Filter cache regenerates correctly after update

## References

- Azure: AB#654
- GX PR: gambio/GX#56