### PR TITLE
AB#683: Fix domain regex false positives on city names and abbreviations

### DIFF
--- a/functions/main.inc.php
+++ b/functions/main.inc.php
@@ -1,6 +1,6 @@
 <?php
 /* --------------------------------------------------------------
-  main.inc.php 2023-02-20
+  main.inc.php 2026-04-02
   Gambio GmbH
   http://www.gambio.de
   Copyright (c) 2023 Gambio GmbH
@@ -370,9 +370,10 @@ function gprotector_block_all_urls_in_registration_form($p_variable)
         // 1) Block obvious URLs (http/https/www) anywhere.
         $reUrl = '/\b(?:https?:\/\/|www\.)\S+/i';
 
-        // 2) Block "naked" domains including new TLDs (.store, .online, etc.) + optional path (e.g. tesst.com/, blogspot.com/Viju).
-        //    This does NOT block abbreviations like "St." or "z. Hd." because it requires a real TLD.
-        $reDomain = '/\b(?:[a-z0-9-]+\.)+(?:[a-z]{2,63}|xn--[a-z0-9-]{2,59})(?:\/\S*)?\b/i';
+        // 2) Block "naked" domains (.store, .online, etc.) + optional path (e.g. tesst.com/, blogspot.com/Viju).
+        //    Requires the first segment to be at least 4 characters to avoid false positives on
+        //    common address abbreviations: "St.Gallen", "a.d.Th.", "zHd.XXY", "Nr.5" etc.
+        $reDomain = '/\b[a-z0-9][a-z0-9-]{2,}[a-z0-9](?:\.[a-z0-9-]+)*\.(?:[a-z]{2,63}|xn--[a-z0-9-]{2,59})(?:\/\S*)?\b/i';
 
         // 3) Block common obfuscations using brackets/parentheses/spaces:
         //    example[.]com, example(.)com, example[dot]com, example(dot)com, example dot com


### PR DESCRIPTION
## Summary

- The naked domain regex in `gprotector_block_all_urls_in_registration_form()` incorrectly flagged legitimate city names and abbreviations as spam domains
- Addresses like "St.Gallen", "a.d.Th.", "St.Gallerstrasse 66", "zHd.XXY" triggered the filter, silently clearing all form fields
- Fix: require the first segment before the dot to be at least 4 characters, distinguishing abbreviations (1-3 chars) from real domains (4+ chars)

## Changes

- `functions/main.inc.php`: Changed `$reDomain` regex — first segment now requires `[a-z0-9][a-z0-9-]{2,}[a-z0-9]` (min 4 chars) instead of `[a-z0-9-]+` (min 1 char)

## Test plan

- [ ] "St.Gallen" in city field → form submits successfully
- [ ] "Schönenberg a.d.Th." in city field → form submits successfully
- [ ] "St.Gallerstrasse 66" in street field → form submits successfully
- [ ] "zHd.XXY" in additional address info → form submits successfully
- [ ] "spam.com" in any field → form fields cleared (blocked)
- [ ] "test.de" in any field → blocked
- [ ] "buy-cheap.store" in any field → blocked
- [ ] "http://evil.com" in any field → blocked (unchanged regex 1)
- [ ] "example[.]com" in any field → blocked (unchanged regex 3)

## References

- Azure: AB#683
- Forum: https://www.gambio.de/forum/threads/url-anti-spambot-mechanic-blockiert-teilweise-ortsnamen-strassen.52785/

🤖 Generated with [Claude Code](https://claude.com/claude-code)